### PR TITLE
Use golang:1.13 to fix the build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest AS build
+FROM golang:1.13 AS build
 COPY . /go/build
 WORKDIR /go/build
 


### PR DESCRIPTION
With the recent `golang:latest` image, the build is failing:

```
$ docker build .
Sending build context to Docker daemon  205.3kB
Step 1/10 : FROM golang:latest AS build
 ---> 861b1afd1d13
Step 2/10 : COPY . /go/build
 ---> e98bab92143f
Step 3/10 : WORKDIR /go/build
 ---> Running in 294f68d2c185
Removing intermediate container 294f68d2c185
 ---> c688f68755de
Step 4/10 : RUN GIT_COMMIT=$(git rev-list -1 HEAD) && go build -o booktaxi -ldflags "-X main.CommitSHA=$GIT_COMMIT" ./src/cmd/booktaxi
 ---> Running in 41b66a1f9400
go: invalid module path "https:": contains disallowed path separator character ':'
The command '/bin/sh -c GIT_COMMIT=$(git rev-list -1 HEAD) && go build -o booktaxi -ldflags "-X main.CommitSHA=$GIT_COMMIT" ./src/cmd/booktaxi' returned a non-zero code: 1
```

I am changing the Dockerfile to use 1.13 as defined in go.mod to fix the build.